### PR TITLE
move storage unregister and layout removal to PinCodeActivity.onPause

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
@@ -45,6 +45,11 @@ public class PinCodeActivity extends AppCompatActivity implements StorageAccessL
         super.onPause();
         LogExt.i(getClass(), "logAccessTime()");
         StorageAccess.getInstance().logAccessTime();
+        storageAccessUnregister();
+        if(pinCodeLayout != null)
+        {
+            getWindowManager().removeView(pinCodeLayout);
+        }
     }
 
     @Override
@@ -53,17 +58,6 @@ public class PinCodeActivity extends AppCompatActivity implements StorageAccessL
         super.onResume();
 
         requestStorageAccess();
-    }
-
-    @Override
-    protected void onDestroy()
-    {
-        super.onDestroy();
-        storageAccessUnregister();
-        if(pinCodeLayout != null)
-        {
-            getWindowManager().removeView(pinCodeLayout);
-        }
     }
 
     protected void requestStorageAccess()


### PR DESCRIPTION
Appears to solve issue of two PIN screens popping up after opening a second app and returning, and the resulting crash.

Can be tested by changing line 82 of `build.gradle (Module: app)` in MoleMapper to `compile 'com.github.mluedke2.ResearchStack:skin:5cf8ed9'`
